### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,6 @@
+gerbers: gerber_v1.2
+bom: gerber_v1.2/bom.csv
+site: https://cast.otter.jetzt/
+eda:
+  type: kicad
+  pcb: OtterCastAmp.kicad_pcb


### PR DESCRIPTION
This adds the file necessary to put up a Kitspace project. If you are happy to have a page for this project, simply merge. If you have any concerns, let me know. 

preview: http://add-ottercast.preview.kitspace.org/boards/github.com/kitspace-forks/OtterCastAmp/ 

One thing to consider regarding BOM: there is no quantity column so quantity is is inferred from references. This may be more brittle than adding an explicit quantity column. 